### PR TITLE
Fix error when accessing settings

### DIFF
--- a/provider.py
+++ b/provider.py
@@ -6,18 +6,12 @@ from .mgrstogeom import MGRStoLayerlgorithm
 
 class LatLonToolsProvider(QgsProcessingProvider):
 
-    def __init__(self):
-        QgsProcessingProvider.__init__(self)
-
-        # Load algorithms
-        self.alglist = [MGRStoLayerlgorithm(),ToMGRSAlgorithm()]
-
     def unload(self):
         QgsProcessingProvider.unload(self)
 
     def loadAlgorithms(self):
-        for alg in self.alglist:
-            self.addAlgorithm( alg )
+        self.addAlgorithm(MGRStoLayerlgorithm())
+        self.addAlgorithm(ToMGRSAlgorithm())
 
     def icon(self):
         return QIcon(os.path.dirname(__file__) + '/images/copyicon.png')


### PR DESCRIPTION
Ownership of algorithms is transferred by calling addAlgorithm,
so loadAlgorithms() needs to return a new instance of each
algorithm whenever it is called