### PR TITLE
Update missing translations for map providers

### DIFF
--- a/i18n/latlonTools_fr.ts
+++ b/i18n/latlonTools_fr.ts
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="2.0" language="fr" sourcelanguage="">
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>@default</name>
     <message>
@@ -644,12 +645,12 @@
     </message>
     <message>
         <location filename="../geom2field.py" line="120"/>
-        <source>D&#xc2;&#xb0;M&apos;S&quot;</source>
+        <source>DÂ°M&apos;S&quot;</source>
         <translation>D°M&apos;S&quot;</translation>
     </message>
     <message>
         <location filename="../geom2field.py" line="120"/>
-        <source>D&#xc2;&#xb0;M.MM&apos;</source>
+        <source>DÂ°M.MM&apos;</source>
         <translation>D°M.MM&apos;</translation>
     </message>
     <message>
@@ -659,12 +660,12 @@
     </message>
     <message>
         <location filename="../geom2field.py" line="128"/>
-        <source>Add space between D&#xc2;&#xb0; M&apos; S&quot; and D&#xc2;&#xb0; M.MM&apos; numbers</source>
+        <source>Add space between DÂ° M&apos; S&quot; and DÂ° M.MM&apos; numbers</source>
         <translation>Ajouter une espace entre les valeurs D° M&apos; S&quot; et D° M.MM&apos;</translation>
     </message>
     <message>
         <location filename="../geom2field.py" line="135"/>
-        <source>Pad D&#xc2;&#xb0;M&apos;S&quot; and D&#xc2;&#xb0;M.MM&apos; coordinates with leading zeros</source>
+        <source>Pad DÂ°M&apos;S&quot; and DÂ°M.MM&apos; coordinates with leading zeros</source>
         <translation>Compléter les coordonnées DÂ°M&apos;S&quot; et DÂ°M.MM&apos; avec des zéros non significatif en début de valeur</translation>
     </message>
     <message>
@@ -895,77 +896,77 @@
     <message>
         <location filename="../showOnMapTool.py" line="80"/>
         <source>Viewing Coordinate</source>
-        <translation type="unfinished"></translation>
+        <translation>Affichage des coordonnées</translation>
     </message>
     <message>
         <location filename="../showOnMapTool.py" line="75"/>
         <source>in Google Earth</source>
-        <translation type="unfinished"></translation>
+        <translation>dans Google Earth</translation>
     </message>
     <message>
         <location filename="../showOnMapTool.py" line="80"/>
         <source>in external map</source>
-        <translation type="unfinished"></translation>
+        <translation>dans la carte externe</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="4"/>
         <source>OSM</source>
-        <translation type="unfinished"></translation>
+        <translation>OSM</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="5"/>
         <source>Google Map</source>
-        <translation type="unfinished"></translation>
+        <translation>Google Maps</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="6"/>
         <source>Google Aerial</source>
-        <translation type="unfinished"></translation>
+        <translation>Google Aerial</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="7"/>
         <source>Bing Map</source>
-        <translation type="unfinished"></translation>
+        <translation>Bing Maps</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="8"/>
         <source>Bing Aerial</source>
-        <translation type="unfinished"></translation>
+        <translation>Bing Aerial</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="9"/>
         <source>MapQuest Map</source>
-        <translation type="unfinished"></translation>
+        <translation>MapQuest Map</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="10"/>
         <source>MapQuest Aerial</source>
-        <translation type="unfinished"></translation>
+        <translation>MapQuest Aerial</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="11"/>
         <source>Mapillary Street</source>
-        <translation type="unfinished"></translation>
+        <translation>Mapillary Street</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="12"/>
         <source>Mapillary Aerial</source>
-        <translation type="unfinished"></translation>
+        <translation>Mapillary Aerial</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="13"/>
         <source>iD Editor ESRI World Imagery</source>
-        <translation type="unfinished"></translation>
+        <translation>Éditeur iD ESRI World Imagery</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="14"/>
         <source>iD Editor OpenTopoMap</source>
-        <translation type="unfinished"></translation>
+        <translation>Éditeur iD OpenTopoMap</translation>
     </message>
     <message>
         <location filename="../mapProviders.py" line="15"/>
         <source>Google Earth Web</source>
-        <translation type="unfinished"></translation>
+        <translation>Google Earth Web</translation>
     </message>
 </context>
 <context>
@@ -1108,15 +1109,15 @@
         <source>GEOREF</source>
         <translation>GEOREF</translation>
     </message>
-    <message encoding="UTF-8">
+    <message>
         <location filename="../ui/coordinateConverter.ui" line="239"/>
         <source>D° M&apos; S&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>D°M&apos;S&quot;</translation>
     </message>
-    <message encoding="UTF-8">
+    <message>
         <location filename="../ui/coordinateConverter.ui" line="246"/>
         <source>D° M.MM&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>D°M.MM&apos;</translation>
     </message>
 </context>
 <context>
@@ -1269,7 +1270,7 @@
     </message>
     <message>
         <location filename="../ui/latLonSettings.ui" line="129"/>
-        <source>D&#xb0;M&apos;S&quot; second precision: </source>
+        <source>D°M&apos;S&quot; second precision: </source>
         <translation type="obsolete">Précision des secondes D°M&apos;S&quot;</translation>
     </message>
     <message>
@@ -1299,7 +1300,7 @@
     </message>
     <message>
         <location filename="../ui/latLonSettings.ui" line="1220"/>
-        <source>D&#xb0; M.MM&apos; precision</source>
+        <source>D° M.MM&apos; precision</source>
         <translation type="obsolete">Précision D° M.MM&apos;</translation>
     </message>
     <message>
@@ -1344,12 +1345,12 @@
     </message>
     <message>
         <location filename="../ui/latLonSettings.ui" line="1327"/>
-        <source>Add space between D&#xb0; M&apos; S&quot; and D&#xb0; M.MM&apos; numbers</source>
+        <source>Add space between D° M&apos; S&quot; and D° M.MM&apos; numbers</source>
         <translation type="obsolete">Ajouter une espace entre les valeurs D° M&apos; S&quot; et D° M.MM&apos;</translation>
     </message>
     <message>
         <location filename="../ui/latLonSettings.ui" line="1334"/>
-        <source>Pad D&#xb0;M&apos;S&quot; and D&#xb0; M.MM&apos; output coordinates with leading zeroes</source>
+        <source>Pad D°M&apos;S&quot; and D° M.MM&apos; output coordinates with leading zeroes</source>
         <translation type="obsolete">Compléter les coordonnées D°M&apos;S&quot; et D° M.MM&apos; avec des zéros non significatifs en début de valeur</translation>
     </message>
     <message>
@@ -1631,7 +1632,7 @@ H3 (si installé) - Seulement les coordonnées H3 geohash</translation>
     </message>
     <message>
         <location filename="../ui/latLonSettings.ui" line="1107"/>
-        <source>D&#xb0;M&apos;S&quot; seconds precision</source>
+        <source>D°M&apos;S&quot; seconds precision</source>
         <translation type="obsolete">Précision secondes D°M&apos;S&quot;</translation>
     </message>
     <message>
@@ -1663,31 +1664,6 @@ H3 (si installé) - Seulement les coordonnées H3 geohash</translation>
         <location filename="../ui/latLonSettings.ui" line="1237"/>
         <source>Maidenhead grid precsion</source>
         <translation>Précision grille Maidenhead</translation>
-    </message>
-    <message encoding="UTF-8">
-        <location filename="../ui/latLonSettings.ui" line="129"/>
-        <source>D°M&apos;S&quot; second precision: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message encoding="UTF-8">
-        <location filename="../ui/latLonSettings.ui" line="1220"/>
-        <source>D° M.MM&apos; precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message encoding="UTF-8">
-        <location filename="../ui/latLonSettings.ui" line="1327"/>
-        <source>Add space between D° M&apos; S&quot; and D° M.MM&apos; numbers</source>
-        <translation type="unfinished">Ajouter une espace entre les valeurs D° M&apos; S&quot; et D° M.MM&apos;</translation>
-    </message>
-    <message encoding="UTF-8">
-        <location filename="../ui/latLonSettings.ui" line="1334"/>
-        <source>Pad D°M&apos;S&quot; and D° M.MM&apos; output coordinates with leading zeroes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message encoding="UTF-8">
-        <location filename="../ui/latLonSettings.ui" line="1107"/>
-        <source>D°M&apos;S&quot; seconds precision</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
QT Linguist told me it found duplicates translations.
For example 
`
<message encoding="UTF-8">
        <location filename="../ui/latLonSettings.ui" line="129"/>
        <source>D°M&apos;S&quot; second precision: </source>
        <translation type="unfinished"></translation>
    </message>
`