### PR TITLE
Use QgsSettings instead of QSettings

### DIFF
--- a/digitizer.py
+++ b/digitizer.py
@@ -1,11 +1,11 @@
 import os
 import re
 
-from qgis.PyQt.QtCore import QSize, QSettings, QTextCodec
+from qgis.PyQt.QtCore import QSize, QTextCodec
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QDialog, QMenu
 from qgis.PyQt.uic import loadUiType
-from qgis.core import Qgis, QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsVectorDataProvider, QgsGeometry, QgsPointXY, QgsJsonUtils, QgsWkbTypes, QgsProject, QgsVectorLayerUtils
+from qgis.core import Qgis, QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsVectorDataProvider, QgsGeometry, QgsPointXY, QgsJsonUtils, QgsWkbTypes, QgsProject, QgsVectorLayerUtils, QgsSettings
 from qgis.gui import QgsProjectionSelectionDialog
 from .util import epsg4326, parseDMSString, tr
 # import traceback
@@ -199,7 +199,7 @@ class DigitizerWidget(QDialog, FORM_CLASS):
         self.crsButton.setDefaultAction(self.crsmenu.actions()[self.inputProjection])
 
     def readSettings(self):
-        settings = QSettings()
+        settings = QgsSettings()
         self.inputProjection = int(settings.value('/LatLonTools/DigitizerProjection', 0))
         self.inputXYOrder = int(settings.value('/LatLonTools/DigitizerXYOrder', 0))
         self.inputCustomCRS = settings.value('/LatLonTools/DigitizerCustomCRS', 'EPSG:4326')
@@ -210,7 +210,7 @@ class DigitizerWidget(QDialog, FORM_CLASS):
         self.labelUpdate()
 
     def saveSettings(self):
-        settings = QSettings()
+        settings = QgsSettings()
         settings.setValue('/LatLonTools/DigitizerProjection', self.inputProjection)
         settings.setValue('/LatLonTools/DigitizerXYOrder', self.inputXYOrder)
         settings.setValue('/LatLonTools/DigitizerCustomCRS', self.inputCustomCRS)

--- a/latLonTools.py
+++ b/latLonTools.py
@@ -1,7 +1,7 @@
-from qgis.PyQt.QtCore import Qt, QTimer, QUrl, QSettings, QTranslator, QCoreApplication
+from qgis.PyQt.QtCore import Qt, QTimer, QUrl, QTranslator, QCoreApplication
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QMenu, QApplication, QToolButton
-from qgis.core import Qgis, QgsCoordinateTransform, QgsVectorLayer, QgsRectangle, QgsPoint, QgsPointXY, QgsGeometry, QgsWkbTypes, QgsProject, QgsApplication
+from qgis.core import Qgis, QgsCoordinateTransform, QgsVectorLayer, QgsRectangle, QgsPoint, QgsPointXY, QgsGeometry, QgsWkbTypes, QgsProject, QgsApplication, QgsSettings
 from qgis.gui import QgsRubberBand
 import processing
 
@@ -30,7 +30,7 @@ class LatLonTools:
 
         # initialize locale
         try:
-            locale = QSettings().value("locale/userLocale", "en", type=str)[0:2]
+            locale = QgsSettings().value("locale/userLocale", "en", type=str)[0:2]
         except Exception:
             locale = "en"
         locale_path = os.path.join(

--- a/settings.py
+++ b/settings.py
@@ -13,10 +13,10 @@ from . import mapProviders
 
 from qgis.PyQt.uic import loadUiType
 from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QFileDialog
-from qgis.PyQt.QtCore import QSettings, Qt
+from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor
 
-from qgis.core import QgsCoordinateReferenceSystem
+from qgis.core import QgsCoordinateReferenceSystem, QgsSettings
 from .util import epsg4326, tr
 
 
@@ -51,7 +51,7 @@ class Settings():
         '''Load the user selected settings. The settings are retained even when
         the user quits QGIS. This just loads the saved information into variables,
         but does not update the widgets. The widgets are updated with showEvent.'''
-        qset = QSettings()
+        qset = QgsSettings()
 
         ### CAPTURE SETTINGS ###
         self.captureShowLocation = int(qset.value('/LatLonTools/CaptureShowClickedLocation', Qt.Unchecked))
@@ -382,7 +382,7 @@ class SettingsWidget(QDialog, FORM_CLASS):
         '''Load the user selected settings. The settings are retained even when
         the user quits QGIS. This just loads the saved information into varialbles,
         but does not update the widgets. The widgets are updated with showEvent.'''
-        qset = QSettings()
+        qset = QgsSettings()
 
         ### CAPTURE SETTINGS ###
         self.captureProjection = int(qset.value('/LatLonTools/CaptureProjection', self.ProjectionTypeWgs84))
@@ -428,7 +428,7 @@ class SettingsWidget(QDialog, FORM_CLASS):
 
     def accept(self):
         '''Accept the settings and save them for next time.'''
-        qset = QSettings()
+        qset = QgsSettings()
 
         ### CAPTURE SETTINGS ###
         qset.setValue('/LatLonTools/CaptureCustomCrsId', self.captureProjectionSelectionWidget.crs().authid())


### PR DESCRIPTION
It is better to use QgsSettings instead of QSettings directly. QSettings only considers the user-specific .ini-file while QgsSettings also looks in the system-wide .ini-file if a key is not definet in the user-file. So with QgsSettings, a system administrator can put some default settings into the system-wide .ini-file (e.g. preset the most frequently used CRS).

Thanks for reviewing this PR