### PR TITLE
MultiZoom dialog: use coordinate format/crs settings from options also when importing from file

### DIFF
--- a/multizoom.py
+++ b/multizoom.py
@@ -239,17 +239,7 @@ class MultiZoomWidget(QDockWidget, FORM_CLASS):
             with open(fname) as f:
                 for line in f:
                     try:
-                        parts = [x.strip() for x in line.split(',')]
-                        if len(parts) >= 2:
-                            lat = parseDMSStringSingle(parts[0])
-                            lon = parseDMSStringSingle(parts[1])
-                            label = ''
-                            data = []
-                            if len(parts) >= 3:
-                                label = parts[2]
-                            if len(parts) >= 4:
-                                data = parts[3:]
-                            self.addCoord(lat, lon, label, data)
+                        self.addSingleCoordLine(line)
                     except Exception:
                         pass
         except Exception:
@@ -300,10 +290,13 @@ class MultiZoomWidget(QDockWidget, FORM_CLASS):
 
             self.resultsTable.blockSignals(False)
             self.resultsTable.clearSelection()
-
+            
     def addSingleCoord(self):
+        self.addSingleCoordLine(self.addLineEdit.text())
+
+    def addSingleCoordLine(self, lineText):
         '''Add a coordinate from the coordinate text box.'''
-        parts = [x.strip() for x in self.addLineEdit.text().split(',')]
+        parts = [x.strip() for x in lineText.split(',')]
         label = ''
         data = []
         numFields = len(parts)


### PR DESCRIPTION
In the option dialog, it is possible to choose CRS and coordinate order settings for multi-zoom. These settings are applied when entering a single line of coordinates. However they are not applied when importing coordinates from file. This PR adds a small change to use the same rules for lines entered by hand as well as imported from file. Like this it is possible to import coordinates in a local CRS (that's my use case).