### PR TITLE
Add Panoramax in external maps

### DIFF
--- a/i18n/latlonTools_fr.ts
+++ b/i18n/latlonTools_fr.ts
@@ -968,6 +968,11 @@
         <translation>Google Earth Web</translation>
     </message>
     <message>
+        <location filename="../mapProviders.py" line="26"/>
+        <source>Panoramax</source>
+        <translation>Panoramax</translation>
+    </message>
+    <message>
         <location filename="../zoomToLatLon.py" line="76"/>
         <source>H3</source>
         <translation type="unfinished"></translation>

--- a/i18n/latlonTools_zh.ts
+++ b/i18n/latlonTools_zh.ts
@@ -508,6 +508,11 @@
         <translation>Google Earth Web</translation>
     </message>
     <message>
+        <location filename="../mapProviders.py" line="26"/>
+        <source>Panoramax</source>
+        <translation>Panoramax</translation>
+    </message>
+    <message>
         <location filename="../tomgrs.py" line="43"/>
         <source>Input point vector layer</source>
         <translation>输入点图层</translation>

--- a/index.html
+++ b/index.html
@@ -331,6 +331,7 @@ code {
 <li><strong>iD Editor ESRI World Imagery</strong></li>
 <li><strong>iD Editor OpenTopoMap</strong></li>
 <li><strong>Google Earth</strong> - (This only works if it is installed on your system)</li>
+<li><strong>Panoramax</strong></li>
 <li><strong>User Added Map Services...</strong></li>
 </ul>
 <p><strong><em>Select an External Map Provider for Right Mouse</em></strong> has the same set of options. These correspond to the left and right mouse buttons.</p>

--- a/mapProviders.py
+++ b/mapProviders.py
@@ -22,5 +22,6 @@ MAP_PROVIDERS = [
     [tr('Mapillary Aerial'), 'https://www.mapillary.com/app/?lat={lat}&lng={lon}&z={zoom}&mapStyle=Mapillary+satellite', 'https://www.mapillary.com/app/?lat={lat}&lng={lon}&z={zoom}&mapStyle=Mapillary+satellite'],
     [tr('iD Editor ESRI World Imagery'), 'https://preview.ideditor.com/master/#background=EsriWorldImagery&disable_features=boundaries&map={zoom}/{lat}/{lon}&overlays=BANO&photo_overlay=mapillary-map-features', 'https://preview.ideditor.com/master/#background=EsriWorldImagery&disable_features=boundaries&map={zoom}/{lat}/{lon}&overlays=BANO&photo_overlay=mapillary-map-features'],
     [tr('iD Editor OpenTopoMap'), 'https://preview.ideditor.com/master/#background=OpenTopoMap&disable_features=boundaries&map={zoom}/{lat}/{lon}&overlays=BANO&photo_overlay=mapillary-map-features','https://preview.ideditor.com/master/#background=OpenTopoMap&disable_features=boundaries&map={zoom}/{lat}/{lon}&overlays=BANO&photo_overlay=mapillary-map-features'],
-    [tr('Google Earth Web'), 'https://earth.google.com/web/search/{lat},{lon}/', 'https://earth.google.com/web/search/{lat},{lon}/']
+    [tr('Google Earth Web'), 'https://earth.google.com/web/search/{lat},{lon}/', 'https://earth.google.com/web/search/{lat},{lon}/'],
+    [tr('Panoramax'), 'https://api.panoramax.xyz/#focus=map&map={zoom}/{lat}/{lon}', 'https://api.panoramax.xyz/#focus=map&map={zoom}/{lat}/{lon}']
 ]

--- a/readme.md
+++ b/readme.md
@@ -277,6 +277,7 @@ You can ***Select an External Map Provider for Left Mouse***. The options are:
 * **iD Editor ESRI World Imagery**
 * **iD Editor OpenTopoMap**
 * **Google Earth** - (This only works if it is installed on your system)
+* **Panoramax**
 * **User Added Map Services...**
 
 ***Select an External Map Provider for Right Mouse*** has the same set of options. These correspond to the left and right mouse buttons.


### PR DESCRIPTION
Hello,

This pull request intends to implement #91 by adding Panoramax link in your plugin. Panoramax is a _street-view like_ platform, all open source with collaborative picture sharing (in a similar fashion of OpenStreetMap). More info about our project : https://panoramax.fr/

The link added points to the complete catalog, which is hosted here: https://api.panoramax.xyz/

Best regards.